### PR TITLE
Node.js/palette conversion: fixed palette size when transparency is missing.

### DIFF
--- a/png-node.coffee
+++ b/png-node.coffee
@@ -206,7 +206,7 @@ module.exports = class PNG
     decodePalette: ->
         palette = @palette
         transparency = @transparency.indexed or []
-        ret = new Buffer(transparency.length + palette.length)
+        ret = new Buffer(palette.length / 3 * 4)
         pos = 0
         length = palette.length
         c = 0

--- a/png-node.js
+++ b/png-node.js
@@ -244,7 +244,7 @@
       var c, i, length, palette, pos, ret, transparency, _ref, _ref2;
       palette = this.palette;
       transparency = this.transparency.indexed || [];
-      ret = new Buffer((transparency.length || 0) + palette.length);
+      ret = new Buffer(palette.length / 3 * 4);
       pos = 0;
       length = palette.length;
       c = 0;


### PR DESCRIPTION
I was testing my code on a non-transparent indexed PNG and some colors were all zeros.
After some debugging, I found that the palette was `c*3` bytes long instead of `c*4` (as it is RGBA, not just RGB), and that its length depended on the transparency map (which didn't exist in my case).
