### PR TITLE
add .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+images
+index.html


### PR DESCRIPTION
When this module is a dependency in our node project, the build has 1.8MB of images for testing that we don't need in our production environment.

This suppresses those files from getting installed into the build.
