### PR TITLE
Added a fail-safe check if images in the buffer contains PNG's magic fixing issue #33

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,23 +1,29 @@
 {
-  "name": "png-js",
-  "description": "A PNG decoder in CoffeeScript",
-  "version": "0.1.1",
-  "author": {
-      "name": "Devon Govett",
-      "email": "devongovett@gmail.com",
-      "url": "http://badassjs.com/"
-  },
-  "repository": {
-      "type": "git",
-      "url": "https://github.com/devongovett/png.js.git"
-  },
-  "bugs": "http://github.com/devongovett/png.js/issues",
-  "devDependencies": {
-      "coffee-script": ">=1.0.1"
-  },
-  "scripts": {
-      "prepublish": "coffee -c png-node.coffee"
-  },
-  "main": "png-node.js",
-  "engine": [ "node >= v0.6.0" ]
+    "name": "png-js",
+    "description": "A PNG decoder in CoffeeScript",
+    "version": "0.1.1",
+    "author": {
+        "name": "Devon Govett",
+        "email": "devongovett@gmail.com",
+        "url": "http://badassjs.com/"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/devongovett/png.js.git"
+    },
+    "bugs": "http://github.com/devongovett/png.js/issues",
+    "devDependencies": {
+        "coffee-script": ">=1.0.1"
+    },
+    "scripts": {
+        "prepublish": "coffee -c png-node.coffee"
+    },
+    "main": "png-node.js",
+    "engine": [
+        "node >= v0.6.0"
+    ],
+    "dependencies": {
+        "@google-cloud/vision": "^0.24.0",
+        "request": "^2.88.0"
+    }
 }

--- a/png-node.js
+++ b/png-node.js
@@ -46,9 +46,16 @@
       return new PNG(file);
     };
 
-    function PNG(data) {
+    function PNG(buffer) {
+      // Check if the buffer contains PNG's magic number
+      // that way, it does not get stuck on a loop and also
+      // saves time.
+      if (buffer[0] != 0x89 && buffer[1] != 0x50 && buffer[2] != 0x4e && buffer[3] != 0x47 
+       && buffer[4] != 0x0d && buffer[5] != 0x0a && buffer[6] != 0x1a && buffer[7] != 0x0a) {
+        throw new Error("Incomplete or corrupt PNG file");
+      }
       var chunkSize, colors, i, index, key, section, short, text, _i, _j, _ref;
-      this.data = data;
+      this.data = buffer;
       this.pos = 8;
       this.palette = [];
       this.imgData = [];


### PR DESCRIPTION
There is a bug in the algorithm on how PNG.load works where if you load a file that is not a PNG. It stucks in a loop. This pull request will fix that.